### PR TITLE
Modified server-example/docker-compose.yml service name

### DIFF
--- a/server-example/docker-compose.yml
+++ b/server-example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  mapfish_print:
+  mapfish-print:
     image: camptocamp/mapfish_print:3.27
     ports:
       - 8080:8080
@@ -11,4 +11,4 @@ services:
       - ./print-apps:/usr/local/tomcat/webapps/ROOT/print-apps
 
 volumes:
-  mapfish_print:
+  mapfish-print:


### PR DESCRIPTION
Changes proposed in this pull request:
- I encountered other docker-compose.yml service accessibility to the service, so I modified service name from `mapfish_print` to `mapfish-print`.

@gtt-project/maintainer
