### PR TITLE
Removed unused supply/resource params from print default config/template

### DIFF
--- a/server-example/print-apps/default/config.yaml
+++ b/server-example/print-apps/default/config.yaml
@@ -56,10 +56,6 @@ templates:
         default: ""
       last_notes: !string
         default: ""
-      supply_items: !string
-        default: ""
-      resource_items: !string
-        default: ""
       image_url_1: !string
         default: "../default/blank.png"
       image_url_2: !string

--- a/server-example/print-apps/default/default.jrxml
+++ b/server-example/print-apps/default/default.jrxml
@@ -32,8 +32,6 @@
 	<parameter name="image_url_3" class="java.lang.String"/>
 	<parameter name="image_url_4" class="java.lang.String"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
-	<parameter name="supply_items" class="java.lang.String"/>
-	<parameter name="resource_items" class="java.lang.String"/>
 	<title>
 		<band height="50" splitType="Stretch">
 			<textField>


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes https://github.com/gtt-project/docker-gtt/pull/15#pullrequestreview-608342627.

Changes proposed in this pull request:
- Removed unused supply/resource params from print default config/template

@gtt-project/maintainer
