### PR TITLE
Feature/configurable before after attachment category

### DIFF
--- a/app/views/gtt_print/_settings.html.erb
+++ b/app/views/gtt_print/_settings.html.erb
@@ -1,3 +1,5 @@
+<h3><%= l(:gtt_print_server_config) %></h3>
+
 <p>
   <%= content_tag(:label, l(:field_gtt_print_server)) %>
   <%= text_field_tag 'settings[default_print_server]', @settings['default_print_server'], :size => 50 %>
@@ -8,11 +10,29 @@
 </p>
 </div>
 
+<% if Redmine::Plugin.installed?(:redmine_attachment_categories) %>
+  <%- attachment_categories = AttachmentCategory.all.collect { |p| [p.name, p.id]} %>
+  <div class="box tabular settings">
+
+  <h3><%= l(:gtt_print_attachment_tag_config) %></h3>
+  <p>
+    <%= content_tag(:label, l(:label_attachment_tag_before)) %>
+    <%= select_tag("settings[attachment_tag_before]",
+                   options_for_select(attachment_categories, @settings['attachment_tag_before'])) %>
+  </p>
+  <p>
+    <%= content_tag(:label, l(:label_attachment_tag_after)) %>
+    <%= select_tag("settings[attachment_tag_after]",
+                   options_for_select(attachment_categories, @settings['attachment_tag_after'])) %>
+  </p>
+  </div>
+<% end %>
+
 <div class="box tabular settings">
 
-<h3><%= l(:gtt_print_configurations) %></h3>
+<h3><%= l(:gtt_print_templates_config) %></h3>
 
-<% Tracker.all.each do |t| %>
+<% Tracker.sorted.each do |t| %>
   <p>
     <%= content_tag :label, t.name %>
     <%= select_tag "settings[tracker_config][#{t.id}]",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,11 @@
 en:
+  gtt_print_server_config: Print server configuration
   field_gtt_print_server: Default print server URL
   field_gtt_print_default_server_timeout: Default print server timeout
-  gtt_print_configurations: Print configurations
+  gtt_print_attachment_tag_config: Print attachment tag configuration
+  label_attachment_tag_before: Before tag
+  label_attachment_tag_after: After tag
+  gtt_print_templates_config: Print template configuration
   label_gtt_list_config: Issue lists
   label_gtt_no_printing: No printing
   label_gtt_print_title: Template Print

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,11 @@
 ja:
-  field_gtt_print_server: デフォルトのプリントサーバーURL
-  field_gtt_print_default_server_timeout: デフォルトのプリントサーバータイムアウト
-  gtt_print_configurations: 印刷設定
+  gtt_print_server_config: 印刷サーバー設定
+  field_gtt_print_server: デフォルトの印刷サーバーURL
+  field_gtt_print_default_server_timeout: デフォルトの印刷サーバータイムアウト
+  gtt_print_attachment_tag_config: 印刷添付ファイルタグ設定
+  label_attachment_tag_before: 対応前タグ
+  label_attachment_tag_after: 対応後タグ
+  gtt_print_templates_config: 印刷テンプレート設定
   label_gtt_list_config: チケットのリスト
   label_gtt_no_printing: (印刷なし)
   label_gtt_print_title: フォーム印刷

--- a/init.rb
+++ b/init.rb
@@ -5,12 +5,12 @@ Rails.configuration.to_prepare do
 end
 
 Redmine::Plugin.register :redmine_gtt_print do
-  name 'Redmine GTT Print Plugin'
+  name 'Redmine GTT Print plugin'
   author 'Georepublic'
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_gtt_print'
   description 'Adds advanced printing capabilities for GTT reports'
-  version '0.1.0'
+  version '1.1.0'
 
   requires_redmine version_or_higher: '4.0.0'
 

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -55,27 +55,37 @@ module RedmineGttPrint
     end
 
     def image_urls(issue)
-      before_image_urls = []
-      after_image_urls = []
-      other_image_urls = []
-      issue.attachments.map do |a|
-        if a.image?
-          if a.attachment_category.nil?
-            other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-          elsif a.attachment_category.id == 1
-            before_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-          elsif a.attachment_category.id == 2
-            after_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-          else
-            other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+      if !Redmine::Plugin.installed?(:redmine_attachment_categories)
+        default_image_urls = []
+        issue.attachments.map do |a|
+          default_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+        end
+        return {
+          "default" => default_image_urls
+        }
+      else
+        before_image_urls = []
+        after_image_urls = []
+        other_image_urls = []
+        issue.attachments.map do |a|
+          if a.image?
+            if a.attachment_category.nil?
+              other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+            elsif a.attachment_category.id == 1
+              before_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+            elsif a.attachment_category.id == 2
+              after_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+            else
+              other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+            end
           end
         end
+        return {
+          "before" => before_image_urls,
+          "after" => after_image_urls,
+          "other" => other_image_urls
+        }
       end
-      return {
-        "before" => before_image_urls,
-        "after" => after_image_urls,
-        "other" => other_image_urls
-      }
     end
 
     # the following static helpers are used by IssuesToJson as well
@@ -115,20 +125,6 @@ module RedmineGttPrint
         # Custom text
         custom_text: other_attributes[:custom_text],
 
-        # Image attachments (max. 4 iamges for each tags)
-        before_image_url_1: image_urls["before"][0] || "../#{layout}/blank.png",
-        before_image_url_2: image_urls["before"][1] || "../#{layout}/blank.png",
-        before_image_url_3: image_urls["before"][2] || "../#{layout}/blank.png",
-        before_image_url_4: image_urls["before"][3] || "../#{layout}/blank.png",
-        after_image_url_1: image_urls["after"][0] || "../#{layout}/blank.png",
-        after_image_url_2: image_urls["after"][1] || "../#{layout}/blank.png",
-        after_image_url_3: image_urls["after"][2] || "../#{layout}/blank.png",
-        after_image_url_4: image_urls["after"][3] || "../#{layout}/blank.png",
-        other_image_url_1: image_urls["other"][0] || "../#{layout}/blank.png",
-        other_image_url_2: image_urls["other"][1] || "../#{layout}/blank.png",
-        other_image_url_3: image_urls["other"][2] || "../#{layout}/blank.png",
-        other_image_url_4: image_urls["other"][3] || "../#{layout}/blank.png",
-
         # Experimental
         # issue: issue,
         # project: (Project.find issue.project_id),
@@ -164,6 +160,27 @@ module RedmineGttPrint
 #           }
 #         }
       }
+
+      # Image attachments (max. 4 iamges for each tags)
+      if !Redmine::Plugin.installed?(:redmine_attachment_categories)
+        result["image_url_1"] = image_urls["default"][0] || "../#{layout}/blank.png"
+        result["image_url_2"] = image_urls["default"][1] || "../#{layout}/blank.png"
+        result["image_url_3"] = image_urls["default"][2] || "../#{layout}/blank.png"
+        result["image_url_4"] = image_urls["default"][3] || "../#{layout}/blank.png"
+      else
+        result["before_image_url_1"] = image_urls["before"][0] || "../#{layout}/blank.png"
+        result["before_image_url_2"] = image_urls["before"][1] || "../#{layout}/blank.png"
+        result["before_image_url_3"] = image_urls["before"][2] || "../#{layout}/blank.png"
+        result["before_image_url_4"] = image_urls["before"][3] || "../#{layout}/blank.png"
+        result["after_image_url_1"] = image_urls["after"][0] || "../#{layout}/blank.png"
+        result["after_image_url_2"] = image_urls["after"][1] || "../#{layout}/blank.png"
+        result["after_image_url_3"] = image_urls["after"][2] || "../#{layout}/blank.png"
+        result["after_image_url_4"] = image_urls["after"][3] || "../#{layout}/blank.png"
+        result["other_image_url_1"] = image_urls["other"][0] || "../#{layout}/blank.png"
+        result["other_image_url_2"] = image_urls["other"][1] || "../#{layout}/blank.png"
+        result["other_image_url_3"] = image_urls["other"][2] || "../#{layout}/blank.png"
+        result["other_image_url_4"] = image_urls["other"][3] || "../#{layout}/blank.png"
+      end
 
       custom_fields.each{|name, value| result["cf_#{name}"] = value || ""}
 

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -20,13 +20,6 @@ module RedmineGttPrint
       @issue = issue
       @layout = layout
       @other_attributes = other_attributes
-
-      @attachment_tag_pattern1 = nil
-      @attachment_tag_pattern2 = nil
-      if Redmine::Plugin.installed?(:redmine_gtt_custom)
-        @attachment_tag_pattern1 = get_attachment_tag_pattern(Setting.plugin_redmine_gtt_custom["attachment_tag_prefixes1"])
-        @attachment_tag_pattern2 = get_attachment_tag_pattern(Setting.plugin_redmine_gtt_custom["attachment_tag_prefixes2"])
-      end
     end
 
     def self.call(*_)
@@ -67,11 +60,11 @@ module RedmineGttPrint
       other_image_urls = []
       issue.attachments.map do |a|
         if a.image?
-          if a.description.nil? or (@attachment_tag_pattern1.nil? and @attachment_tag_pattern2.nil?)
+          if a.attachment_category.nil?
             other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-          elsif a.description.match(@attachment_tag_pattern1)
+          elsif a.attachment_category.id == 1
             before_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-          elsif a.description.match(@attachment_tag_pattern2)
+          elsif a.attachment_category.id == 2
             after_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
           else
             other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -71,9 +71,9 @@ module RedmineGttPrint
           if a.image?
             if a.attachment_category.nil?
               other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-            elsif a.attachment_category.id == 1
+            elsif a.attachment_category.id == Setting.plugin_redmine_gtt_print['attachment_tag_before'].to_i
               before_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
-            elsif a.attachment_category.id == 2
+            elsif a.attachment_category.id == Setting.plugin_redmine_gtt_print['attachment_tag_after'].to_i
               after_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
             else
               other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -20,6 +20,13 @@ module RedmineGttPrint
       @issue = issue
       @layout = layout
       @other_attributes = other_attributes
+
+      @attachment_tag_pattern1 = nil
+      @attachment_tag_pattern2 = nil
+      if Redmine::Plugin.installed?(:redmine_gtt_custom)
+        @attachment_tag_pattern1 = get_attachment_tag_pattern(Setting.plugin_redmine_gtt_custom["attachment_tag_prefixes1"])
+        @attachment_tag_pattern2 = get_attachment_tag_pattern(Setting.plugin_redmine_gtt_custom["attachment_tag_prefixes2"])
+      end
     end
 
     def self.call(*_)
@@ -55,13 +62,27 @@ module RedmineGttPrint
     end
 
     def image_urls(issue)
-      image_urls = []
+      before_image_urls = []
+      after_image_urls = []
+      other_image_urls = []
       issue.attachments.map do |a|
         if a.image?
-          image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+          if a.description.nil? or (@attachment_tag_pattern1.nil? and @attachment_tag_pattern2.nil?)
+            other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+          elsif a.description.match(@attachment_tag_pattern1)
+            before_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+          elsif a.description.match(@attachment_tag_pattern2)
+            after_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+          else
+            other_image_urls.push(download_named_attachment_url(a, a.filename, key: User.current.api_key))
+          end
         end
       end
-      return image_urls
+      return {
+        "before" => before_image_urls,
+        "after" => after_image_urls,
+        "other" => other_image_urls
+      }
     end
 
     # the following static helpers are used by IssuesToJson as well
@@ -101,11 +122,19 @@ module RedmineGttPrint
         # Custom text
         custom_text: other_attributes[:custom_text],
 
-        # Image attachments (max. 4 iamges)
-        image_url_1: image_urls[0] || "../#{layout}/blank.png",
-        image_url_2: image_urls[1] || "../#{layout}/blank.png",
-        image_url_3: image_urls[2] || "../#{layout}/blank.png",
-        image_url_4: image_urls[3] || "../#{layout}/blank.png",
+        # Image attachments (max. 4 iamges for each tags)
+        before_image_url_1: image_urls["before"][0] || "../#{layout}/blank.png",
+        before_image_url_2: image_urls["before"][1] || "../#{layout}/blank.png",
+        before_image_url_3: image_urls["before"][2] || "../#{layout}/blank.png",
+        before_image_url_4: image_urls["before"][3] || "../#{layout}/blank.png",
+        after_image_url_1: image_urls["after"][0] || "../#{layout}/blank.png",
+        after_image_url_2: image_urls["after"][1] || "../#{layout}/blank.png",
+        after_image_url_3: image_urls["after"][2] || "../#{layout}/blank.png",
+        after_image_url_4: image_urls["after"][3] || "../#{layout}/blank.png",
+        other_image_url_1: image_urls["other"][0] || "../#{layout}/blank.png",
+        other_image_url_2: image_urls["other"][1] || "../#{layout}/blank.png",
+        other_image_url_3: image_urls["other"][2] || "../#{layout}/blank.png",
+        other_image_url_4: image_urls["other"][3] || "../#{layout}/blank.png",
 
         # Experimental
         # issue: issue,

--- a/test/unit/issue_to_json_test.rb
+++ b/test/unit/issue_to_json_test.rb
@@ -51,7 +51,11 @@ class IssueToJsonTest < ActiveSupport::TestCase
     assert j = RedmineGttPrint::IssueToJson.(i, 'layout')
     assert h = JSON.parse(j)
     assert_equal i.subject, h['attributes']['subject']
-    assert h['attributes']['other_image_url_1'].present?
+    if !Redmine::Plugin.installed?(:redmine_attachment_categories)
+      assert h['attributes']['image_url_1'].present?
+    else
+      assert h['attributes']['other_image_url_1'].present?
+    end
     assert_nil h['attributes']['map']
   end
 


### PR DESCRIPTION
Supports #14.

~~**NOTE: PR target is `0.1-stable` branch to support existing customer.**~~

Changes proposed in this pull request:
- Revert "Simplified image urls":
  - commit diff: https://github.com/gtt-project/redmine_gtt_print/commit/911fe8d2d39d92e928a1777624d257e5753e8073
- Switched attachment logic plugin
- Supported both installed and not installed attachment_categories plugin cases
- Configurable attachment before/after tag

@gtt-project/maintainer
