### PR TITLE
Added **kwargs to call methond as keyword arguments

### DIFF
--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -22,8 +22,8 @@ module RedmineGttPrint
       @other_attributes = other_attributes
     end
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def call

--- a/lib/redmine_gtt_print/issues_to_json.rb
+++ b/lib/redmine_gtt_print/issues_to_json.rb
@@ -13,8 +13,8 @@ module RedmineGttPrint
       @custom_fields_for_all = IssueCustomField.where(is_for_all: true).sort
     end
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def call


### PR DESCRIPTION
Fixes possible error on Redmine5.0 + Ruby3.1 environment.

Changes proposed in this pull request:
- Added `**kwargs` to call methond as keyword arguments

@gtt-project/maintainer
