### PR TITLE
Exposed 'is_public' method of issue formatter

### DIFF
--- a/lib/redmine_gtt_print/issue_formatter.rb
+++ b/lib/redmine_gtt_print/issue_formatter.rb
@@ -12,6 +12,10 @@ module RedmineGttPrint
       format_object @issue.is_private, false
     end
 
+    def is_public
+      format_object !@issue.is_private, false
+    end
+
     def start_date
       format_object @issue.start_date, false
     end

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -113,6 +113,7 @@ module RedmineGttPrint
         assigned_to_name: issue.assigned_to&.name || "",
         description: issue.description,
         is_private: formatter.is_private,
+        is_public: formatter.is_public,
         start_date: formatter.start_date || "",
         done_date: formatter.closed_on || "",
         # due_date: issue.due_date,


### PR DESCRIPTION
Changes proposed in this pull request:
- Expose `is_public` method of issue formatter.

@gtt-project/maintainer
