### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,1 +1,10 @@
-{}
+gtt_print_configurations: Druck-Konfigurationen
+label_gtt_list_config: Liste der Tickets
+label_gtt_no_printing: Kein Drucken
+label_gtt_print_title: Vorlagen Druck
+label_gtt_print_failed: Drucken ist fehlgeschlagen
+button_gtt_print_submit: Drucken
+permission_view_gtt_smash: GTT print ansehen
+project_module_gtt_smash: GTT print
+field_gtt_print_server: Standard-URL des Druckservers
+field_gtt_print_default_server_timeout: Standard-Timeout des Druckservers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,4 +7,5 @@ ja:
   label_gtt_print_title: フォーム印刷
   label_gtt_print_failed: 印刷に失敗しました
   button_gtt_print_submit: 印刷
-  project_module_gtt_print: "GTTフォーム印刷"
+  project_module_gtt_smash: GTT 印刷
+  permission_view_gtt_smash: GTT 印刷の閲覧


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine GTT Print plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_gtt_print/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/gtt-project/-/redmine_gtt_print/horizontal-auto.svg)