### PR TITLE
Use project geometry center if issue geometry is nil (#23)

### DIFF
--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -44,6 +44,12 @@ module RedmineGttPrint
       if data = @issue.geodata_for_print
         json[:attributes][:map] = self.class.map_data(data[:center], [data[:geojson]],
           scale, basemap_url)
+      else
+        project = Project.find(@issue.project_id)
+        if data = project.geodata_for_print
+          json[:attributes][:map] = self.class.map_data(data[:center], [],
+            scale, basemap_url)
+        end
       end
 
       context = {


### PR DESCRIPTION
Fixes #23

Changes proposed in this pull request:
- Use project geometry center if issue geometry is nil.

@gtt-project/maintainer
