### PR TITLE
Filter out unsupported image format

### DIFF
--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -66,7 +66,8 @@ module RedmineGttPrint
         title: "attachments",
         table: {
           columns: attachment_columns,
-          data: attachments.map {|a| attachment_to_data_row a}
+          data: attachments.where("filename ~* ?", '\.(jpg|jpeg|png|bmp|gif)$')
+                  .map {|a| attachment_to_data_row a}
         }
       }
     end


### PR DESCRIPTION
Fixes unsupported image format (PDF ,etc.) printing error.

Changes proposed in this pull request:
- Limit printing image format to JPG/PNG/BMP/GIF which are supported in Redmine image preview.

@gtt-project/maintainer
