### PR TITLE
Use default scale and basemap

### DIFF
--- a/app/controllers/gtt_print_jobs_controller.rb
+++ b/app/controllers/gtt_print_jobs_controller.rb
@@ -54,7 +54,7 @@ class GttPrintJobsController < ApplicationController
   private
 
   def gtt_print_job_params
-    params[:gtt_print_job].permit(:layout, :custom_text, :scale, :basemap_url)
+    params[:gtt_print_job].permit(:layout, :custom_text)
   end
 
   def authorize_create

--- a/app/models/gtt_print_job.rb
+++ b/app/models/gtt_print_job.rb
@@ -3,7 +3,7 @@
 class GttPrintJob
   include ActiveModel::Model
 
-  attr_accessor :layout, :custom_text, :issue, :issues, :scale, :basemap_url
+  attr_accessor :layout, :custom_text, :issue, :issues
 
   validates :layout, presence: true
   validates :issue, presence: true,  if: ->{ issues.nil? }
@@ -17,8 +17,7 @@ class GttPrintJob
     if list?
       RedmineGttPrint::IssuesToJson.(issues, layout, custom_text: custom_text)
     else
-      RedmineGttPrint::IssueToJson.(issue, layout, { custom_text: custom_text,
-        scale: scale, basemap_url: basemap_url })
+      RedmineGttPrint::IssueToJson.(issue, layout, custom_text: custom_text)
     end
   end
 

--- a/app/views/hooks/_print_issue_form.html.erb
+++ b/app/views/hooks/_print_issue_form.html.erb
@@ -1,10 +1,8 @@
 <% is_sync = RedmineGttPrint.settings['enable_sync_printing'] == 'true' %>
 <% if @issue and User.current.allowed_to?(:view_gtt_print, @issue.project) and (layouts = RedmineGttPrint.layouts_for_tracker(@issue.tracker)).any? %>
   <h3><%= l :label_gtt_print_title %></h3>
-  <%= form_for :gtt_print_job, :html => { :onsubmit => '_submit()' }, url: gtt_print_jobs_path, local: is_sync, remote: !is_sync  do |f| %>
+  <%= form_for :gtt_print_job, url: gtt_print_jobs_path, local: is_sync, remote: !is_sync do |f| %>
     <%= hidden_field_tag :issue_id, @issue.id %>
-    <%= f.hidden_field :scale  %>
-    <%= f.hidden_field :basemap_url %>
     <%= f.text_area :custom_text %><br>
     <%= f.select :layout, options_from_collection_for_select(layouts, :to_s, :to_s) %>
     <button type="submit"><%= l :button_gtt_print_submit %></button>

--- a/assets/javascripts/gtt_print.js
+++ b/assets/javascripts/gtt_print.js
@@ -1,18 +1,18 @@
 /**
  * GttPrint
- * 
+ *
  * en:
  * This script describes the JavaScript portion of the GTT Print plug-in.
- * 
+ *
  * ## Design policy.
  * * Use the namespace `GttPrint` to avoid `Global Pollution`.
  * * Define methods for constants in `consts` objects, event handlers in `handlers` objects, and initialization processes in `initializers` objects.
  * * To avoid the complexity caused by implicit this-reference conversion, the methods in the `consts` `handlers` `initializers` objects are referenced from the `GttPrint` namespace and assigned to local variables at the beginning of each method.
  * * The initialization process is performed by calling `GttPrint.init()` in `$(document).ready`. This ensures that the initialization process is executed after the DOM has been rendered.
- * 
+ *
  * ja:
  * このスクリプトは、GTT PrintプラグインのJavaScript部分を記述します。
- * 
+ *
  * ## 設計方針
  * * グローバル汚染を回避するため、名前空間 `GttPrint` を使用します。
  * * 定数は `consts`オブジェクトに、イベントハンドラは `handlers` オブジェクトに、初期化処理は `initializers` オブジェクトに、それぞれメソッドを定義します。
@@ -78,12 +78,6 @@ var GttPrint = {
     }, 500);
   }
 };
-
-var _submit = function () {
-  $('input[name="gtt_print_job[scale]"]').val(App.getScale());
-  $('input[name="gtt_print_job[basemap_url]"]').val(App.getBasemapUrl());
-}
-
 
 $(document).ready(function () {
   GttPrint.init();

--- a/lib/redmine_gtt_print/issue_to_json.rb
+++ b/lib/redmine_gtt_print/issue_to_json.rb
@@ -37,10 +37,14 @@ module RedmineGttPrint
       }
 
       scale = nil
+      default_map_fit_maxzoom_level = Setting.plugin_redmine_gtt['default_map_fit_maxzoom_level']
+      if default_map_fit_maxzoom_level.present? && default_map_fit_maxzoom_level.to_i > 0
+        scale = 559081145.8641895 / 2 ** default_map_fit_maxzoom_level.to_i
+      end
       basemap_url = nil
-      if !@other_attributes.nil?
-        scale = @other_attributes[:scale]
-        basemap_url = @other_attributes[:basemap_url]
+      project_tile_sources = @issue.project.gtt_tile_sources
+      if project_tile_sources.present?
+        basemap_url = project_tile_sources.first.options['url']
       end
       if data = @issue.geodata_for_print
         json[:attributes][:map] = self.class.map_data(data[:center], [data[:geojson]],


### PR DESCRIPTION
Fixes #13.

Changes proposed in this pull request:
- Revert past `supporting print mapzoom and tileswitch function` commit (https://github.com/gtt-project/redmine_gtt_print/commit/a0b60ea0f6ffcfb46526ae6ea317e0730b960c3c) except `issue_to_json.rb`.
- Use default map scale and project tile source.

@gtt-project/maintainer
