### PR TITLE
Fix nil error in redmine 5.1

### DIFF
--- a/lib/redmine_gtt_print/issues_to_json.rb
+++ b/lib/redmine_gtt_print/issues_to_json.rb
@@ -60,9 +60,9 @@ module RedmineGttPrint
       columns = [
         i.id.to_s,
         i.status.name,
-        i.start_date,
+        i.start_date || "",
         i.created_on,
-        i.assigned_to&.name,
+        i.assigned_to&.name || "",
         i.subject,
         i.description
       ]


### PR DESCRIPTION
Fixes MapFish Print side `NullPointerException` error in Redmine 5.1 environment.

Changes proposed in this pull request:
- Fix nil error in redmine 5.1

@gtt-project/maintainer
